### PR TITLE
Add git describe, to show the currently deployed tag

### DIFF
--- a/design/standard/templates/sysinfo/sourcerevision.tpl
+++ b/design/standard/templates/sysinfo/sourcerevision.tpl
@@ -39,6 +39,17 @@
 {/foreach}
 </table>
 
+<table class="list" cellspacing="0">
+  <tr>
+    <th>GIT Tag</th>
+  </tr>
+{foreach $tag_info as $result sequence array( 'bglight', 'bgdark') as $style}
+  <tr class="{$style}">
+    <td>{$result|wash()}</td>
+  </tr>
+{/foreach}
+</table>
+
 </pre>
 
 </div>

--- a/modules/sysinfo/sourcerevision.php
+++ b/modules/sysinfo/sourcerevision.php
@@ -13,5 +13,10 @@ $statusInfo = array();
 $retcode = 0;
 exec( "cd .. && git status", $statusInfo, $retcode );
 
+$tagInfo = array();
+$retcode = 0;
+exec( "cd .. && git describe", $tagInfo, $retcode );
+
 $tpl->setVariable( 'revision_info', $revisionInfo );
 $tpl->setVariable( 'status_info', $statusInfo );
+$tpl->setVariable( 'tag_info', $tagInfo );


### PR DESCRIPTION
Useful for prod environments, which may use a tag in place of a branch.
